### PR TITLE
first pass cleanup of function generation.  used of spaces instead of tabs (indentation set at 4 spaces)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ kotlin/src/main/generated-sources
 kotlin/src/main/xtend-gen
 kotlin-feature.code-workspace
 .pydevenv
+python/.pydevproject

--- a/python/build/build_python_rosetta.sh
+++ b/python/build/build_python_rosetta.sh
@@ -21,21 +21,23 @@ fi
 
 ACDIR=$($PYEXE -c "import sys;print('Scripts' if sys.platform.startswith('win') else 'bin')")
 
+$PYEXE -m venv --clear .pydevenv || processError
+source .pydevenv/$ACDIR/activate || processError
+
 MYPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROSETTARUNTIMEDIR=$MYPATH/"../src/main/resources/runtime"
 PYTHONSOURCEDIR=$MYPATH/"../target/python"
 cd $PYTHONSOURCEDIR
 rm python_cdm-*.*.*-py3-none-any.whl
-$PYEXE -m venv --clear .pyenv || processError
-source .pyenv/$ACDIR/activate || processError
 $PYEXE -m pip install --upgrade pip || processError
 $PYEXE -m pip install "setuptools>=62.0" || processError
 $PYEXE -m pip install "pydantic>=2.0.0" || processError
 $PYEXE -m pip install jsonpickle || processError
-$PYEXE -m pip install $ROSETTARUNTIMEDIR/rosetta_runtime-2.0.0-py3-none-any.whl || processError
+$PYEXE -m pip install $ROSETTARUNTIMEDIR/rosetta_runtime-3.0.0-py3-none-any.whl || processError
 
 $PYEXE -m pip wheel --no-deps --only-binary :all: . || processError
-rm -rf  .pyenv target/python/.pyenv
+
+#rm -rf  .pyenv target/python/.pydevenv
 echo ""
 echo ""
 echo "***************************************************************************"

--- a/python/src/main/java/com/regnosys/rosetta/generator/python/enums/PythonEnumGenerator.xtend
+++ b/python/src/main/java/com/regnosys/rosetta/generator/python/enums/PythonEnumGenerator.xtend
@@ -12,65 +12,65 @@ import java.util.Map
 
 class PythonEnumGenerator {
 
-	@Inject extension PythonModelObjectBoilerPlate
-	
-	@Inject
-	PythonModelGeneratorUtil utils;
-	
-	
+    @Inject extension PythonModelObjectBoilerPlate
+    
+    @Inject
+    PythonModelGeneratorUtil utils;
+    
+    
 
-	def Map<String, ? extends CharSequence> generate(Iterable<RosettaEnumeration> rosettaEnums, String version) {
-		val result = new HashMap
-		for(RosettaEnumeration enum: rosettaEnums){
-			val tr = enum.eContainer as RosettaModel
-			val namespace = tr.name
-			val enums = enum.generateEnums(version).replaceTabsWithSpaces
-		
-			val all = 
-			'''
-			from enum import Enum
-			
-			all = ['«enum.name»']
-			  
-			'''
-			result.put(utils.toPyFileName(namespace, enum.name), all +enums)
-		}
-		return result;
-	}
+    def Map<String, ? extends CharSequence> generate(Iterable<RosettaEnumeration> rosettaEnums, String version) {
+        val result = new HashMap
+        for(RosettaEnumeration enum: rosettaEnums){
+            val tr = enum.eContainer as RosettaModel
+            val namespace = tr.name
+            val enums = enum.generateEnums(version).replaceTabsWithSpaces
+        
+            val all = 
+            '''
+            from enum import Enum
+            
+            all = ['«enum.name»']
+              
+            '''
+            result.put(utils.toPyFileName(namespace, enum.name), all +enums)
+        }
+        return result;
+    }
 
-	private def allEnumsValues(RosettaEnumeration enumeration) {
-		val enumValues = new ArrayList
-		var e = enumeration;
+    private def allEnumsValues(RosettaEnumeration enumeration) {
+        val enumValues = new ArrayList
+        var e = enumeration;
 
-		while (e !== null) {
-			e.enumValues.forEach[enumValues.add(it)]
-			e = e.superType
-		}
-		return enumValues.sortBy[name];
-	}
+        while (e !== null) {
+            e.enumValues.forEach[enumValues.add(it)]
+            e = e.superType
+        }
+        return enumValues.sortBy[name];
+    }
 
-	private def generateEnums(RosettaEnumeration enume, String version){
+    private def generateEnums(RosettaEnumeration enume, String version){
 
-		'''
-		«val allEnumValues = allEnumsValues(enume)»
-		class «enume.name»(Enum):
-			«IF enume.definition!==null»
-			"""
-			«enume.definition»
-			"""
-			«ENDIF»
-			«IF allEnumValues.size()===0»
-			pass
-			«ELSE»
-			«FOR value: allEnumValues SEPARATOR ''»
-			«EnumHelper.convertValues(value)» = "«IF value.display !== null»«value.display»«ELSE»«EnumHelper.convertValues(value)»«ENDIF»"
-			«IF value.definition!==null»
-			"""
-			«value.definition»
-			"""
-			«ENDIF»
-			«ENDFOR»
-			«ENDIF»
-		'''
-	}
+        '''
+        «val allEnumValues = allEnumsValues(enume)»
+        class «enume.name»(Enum):
+            «IF enume.definition!==null»
+            """
+            «enume.definition»
+            """
+            «ENDIF»
+            «IF allEnumValues.size()===0»
+            pass
+            «ELSE»
+            «FOR value: allEnumValues SEPARATOR ''»
+            «EnumHelper.convertValues(value)» = "«IF value.display !== null»«value.display»«ELSE»«EnumHelper.convertValues(value)»«ENDIF»"
+            «IF value.definition!==null»
+            """
+            «value.definition»
+            """
+            «ENDIF»
+            «ENDFOR»
+            «ENDIF»
+        '''
+    }
 }

--- a/python/src/main/java/com/regnosys/rosetta/generator/python/expressions/PythonExpressionGenerator.xtend
+++ b/python/src/main/java/com/regnosys/rosetta/generator/python/expressions/PythonExpressionGenerator.xtend
@@ -57,17 +57,17 @@ import com.regnosys.rosetta.rosetta.simple.Segment
 import com.regnosys.rosetta.rosetta.expression.EqualityOperation
 
 class PythonExpressionGenerator {
-	
-	@Inject extension RosettaExtensions
-	@Inject extension PythonModelObjectBoilerPlate
+    
+    @Inject extension RosettaExtensions
+    @Inject extension PythonModelObjectBoilerPlate
 
-	@Inject
-	PythonModelGeneratorUtil utils;
-	
-	public var List<String> importsFound
-	public var if_cond_blocks = new ArrayList<String>()
-	
-	public def generateConditions(Data cls) {
+    @Inject
+    PythonModelGeneratorUtil utils;
+    
+    public var List<String> importsFound
+    public var if_cond_blocks = new ArrayList<String>()
+    
+    public def generateConditions(Data cls) {
         // Move your condition and expression-related logic here
         var n_condition = 0;
         var res = '';
@@ -89,7 +89,7 @@ class PythonExpressionGenerator {
         for (Condition cond : conditions) {
             res += generateConditionBoilerPlate(cond, n_condition)
             if (cond.isConstraintCondition)
-            	println('A')
+                println('A')
                 //res += generateConstraintCondition(cls, cond)
             else
                 res += generateExpressionCondition(cond)
@@ -106,7 +106,7 @@ class PythonExpressionGenerator {
         for (Condition cond : conditions) {
             res += generatePostConditionBoilerPlate(cond, n_condition)
             if (cond.isConstraintCondition)
-            	println('A')
+                println('A')
                 //res += generateConstraintCondition(cls, cond)
             else
                 res += generateExpressionCondition(cond)
@@ -117,389 +117,389 @@ class PythonExpressionGenerator {
     }
 
     def boolean isConstraintCondition(Condition cond) {
-		return cond.isOneOf || cond.isChoice
-	}
+        return cond.isOneOf || cond.isChoice
+    }
 
-	private def boolean isOneOf(Condition cond) {
-		return cond.expression instanceof OneOfOperation
-	}
+    private def boolean isOneOf(Condition cond) {
+        return cond.expression instanceof OneOfOperation
+    }
 
-	private def boolean isChoice(Condition cond) {
-		return cond.expression instanceof ChoiceOperation
-	}
+    private def boolean isChoice(Condition cond) {
+        return cond.expression instanceof ChoiceOperation
+    }
 
     private def generateConditionBoilerPlate(Condition cond, int n_condition) {
-		'''
-			
-			@rosetta_condition
-			def condition_«n_condition»_«cond.name»(self):
-				«IF cond.definition!==null»
-					"""
-					«cond.definition»
-					"""
-				«ENDIF»
-		'''
-	}
+        '''
+            
+            @rosetta_condition
+            def condition_«n_condition»_«cond.name»(self):
+                «IF cond.definition!==null»
+                    """
+                    «cond.definition»
+                    """
+                «ENDIF»
+        '''
+    }
 
-	private def generatePostConditionBoilerPlate(Condition cond, int n_condition) {
-		'''
-			
-			@rosetta_condition
-			def post_condition_«n_condition»_«cond.name»(self):
-				«IF cond.definition!==null»
-					"""
-					«cond.definition»
-					"""
-				«ENDIF»
-		'''
-	}
+    private def generatePostConditionBoilerPlate(Condition cond, int n_condition) {
+        '''
+            
+            @rosetta_condition
+            def post_condition_«n_condition»_«cond.name»(self):
+                «IF cond.definition!==null»
+                    """
+                    «cond.definition»
+                    """
+                «ENDIF»
+        '''
+    }
 
-	private def generateConstraintCondition(Data cls, Condition cond) {
-		val expression = cond.expression
-		var attributes = cls.attributes
-		var necessity = "necessity=True"
+    private def generateConstraintCondition(Data cls, Condition cond) {
+        val expression = cond.expression
+        var attributes = cls.attributes
+        var necessity = "necessity=True"
 
-		if (expression instanceof ChoiceOperation) {
-			attributes = expression.attributes
-			if (expression.necessity == Necessity.OPTIONAL) {
-				necessity = "necessity=False"
-			}
-		}
-		'''	return self.check_one_of_constraint(«FOR a : attributes SEPARATOR ", "»'«a.name»'«ENDFOR», «necessity»)
-		'''
-	}
+        if (expression instanceof ChoiceOperation) {
+            attributes = expression.attributes
+            if (expression.necessity == Necessity.OPTIONAL) {
+                necessity = "necessity=False"
+            }
+        }
+        '''    return self.check_one_of_constraint(«FOR a : attributes SEPARATOR ", "»'«a.name»'«ENDFOR», «necessity»)
+        '''
+    }
 
-	private def generateExpressionCondition(Condition c) {
-		if_cond_blocks = new ArrayList<String>()
-		var expr = generateExpression(c.expression, 0)
-		var blocks = ""
-		if (!if_cond_blocks.isEmpty()) {
-			blocks = '''	«FOR arg : if_cond_blocks»«arg»«ENDFOR»'''
-		}
-		return '''«blocks»	return «expr»
-		'''
-	}
+    private def generateExpressionCondition(Condition c) {
+        if_cond_blocks = new ArrayList<String>()
+        var expr = generateExpression(c.expression, 0)
+        var blocks = ""
+        if (!if_cond_blocks.isEmpty()) {
+            blocks = '''    «FOR arg : if_cond_blocks»«arg»«ENDFOR»'''
+        }
+        return '''«blocks»    return «expr»
+        '''
+    }
 
-	def generateExpressionThenElse(RosettaExpression expr, List<Integer> iflvl) {
-	    if_cond_blocks = new ArrayList<String>()
-	    val expression = generateExpression(expr, iflvl.get(0))
-	
-	    var blocks = ""
-	    if (!if_cond_blocks.isEmpty()) {
-	        iflvl.set(0, iflvl.get(0) + 1)
-	        blocks = '''	«FOR arg : if_cond_blocks»«arg»«ENDFOR»'''
-	    }
-	    return '''«blocks»'''
-	}
+    def generateExpressionThenElse(RosettaExpression expr, List<Integer> iflvl) {
+        if_cond_blocks = new ArrayList<String>()
+        val expression = generateExpression(expr, iflvl.get(0))
+    
+        var blocks = ""
+        if (!if_cond_blocks.isEmpty()) {
+            iflvl.set(0, iflvl.get(0) + 1)
+            blocks = '''    «FOR arg : if_cond_blocks»«arg»«ENDFOR»'''
+        }
+        return '''«blocks»'''
+    }
 
-	def String generateExpression(RosettaExpression expr, int iflvl) {
-		switch (expr) {
-			RosettaConditionalExpression: {
-				// val nslashes = (2**iflvl - 1) as int;
-				// val escsec = '\\'.repeat(nslashes) + "'";
-				val ifexpr = generateExpression(expr.getIf(), iflvl + 1)
-				val ifthen = generateExpression(expr.ifthen, iflvl + 1)
-				var elsethen = expr.elsethen !== null && expr.full ? generateExpression(expr.elsethen,
-						iflvl + 1) : 'True'
+    def String generateExpression(RosettaExpression expr, int iflvl) {
+        switch (expr) {
+            RosettaConditionalExpression: {
+                // val nslashes = (2**iflvl - 1) as int;
+                // val escsec = '\\'.repeat(nslashes) + "'";
+                val ifexpr = generateExpression(expr.getIf(), iflvl + 1)
+                val ifthen = generateExpression(expr.ifthen, iflvl + 1)
+                var elsethen = expr.elsethen !== null && expr.full ? generateExpression(expr.elsethen,
+                        iflvl + 1) : 'True'
 
-				val if_blocks = '''
-					def _then_fn«iflvl»():
-						return «ifthen»
+                val if_blocks = '''
+                    def _then_fn«iflvl»():
+                        return «ifthen»
 
-					def _else_fn«iflvl»():
-						return «elsethen»
+                    def _else_fn«iflvl»():
+                        return «elsethen»
 
-				'''
-				if_cond_blocks.add(if_blocks)
+                '''
+                if_cond_blocks.add(if_blocks)
 
-				// '''if_cond(«ifexpr», «escsec»«ifthen»«escsec», «escsec»«elsethen»«escsec», self)'''
-				'''if_cond_fn(«ifexpr», _then_fn«iflvl», _else_fn«iflvl»)'''
-			}
-			RosettaFeatureCall: {
-				var right = switch (expr.feature) {
-					Attribute: {
-						expr.feature.name
-					}
-					RosettaMetaType: {
-						expr.feature.name
-					}
-					RosettaEnumValue: {
-						val rosettaValue = expr.feature as RosettaEnumValue
-						val value = EnumHelper.convertValues(rosettaValue)
+                // '''if_cond(«ifexpr», «escsec»«ifthen»«escsec», «escsec»«elsethen»«escsec», self)'''
+                '''if_cond_fn(«ifexpr», _then_fn«iflvl», _else_fn«iflvl»)'''
+            }
+            RosettaFeatureCall: {
+                var right = switch (expr.feature) {
+                    Attribute: {
+                        expr.feature.name
+                    }
+                    RosettaMetaType: {
+                        expr.feature.name
+                    }
+                    RosettaEnumValue: {
+                        val rosettaValue = expr.feature as RosettaEnumValue
+                        val value = EnumHelper.convertValues(rosettaValue)
 
-						val symbol = (expr.receiver as RosettaSymbolReference).symbol
-						val model = symbol.eContainer as RosettaModel
-						addImportsFromConditions(symbol.name, model.name)
+                        val symbol = (expr.receiver as RosettaSymbolReference).symbol
+                        val model = symbol.eContainer as RosettaModel
+                        addImportsFromConditions(symbol.name, model.name)
 
-						value
-					}
-					// TODO: RosettaFeature: '''.Select(x => x.«feature.name.toFirstUpper»)'''
-					RosettaFeature: {
-						expr.feature.name
-					}
-					default:
-						throw new UnsupportedOperationException("Unsupported expression type of " +
-							expr.feature.eClass.name)
-				}
+                        value
+                    }
+                    // TODO: RosettaFeature: '''.Select(x => x.«feature.name.toFirstUpper»)'''
+                    RosettaFeature: {
+                        expr.feature.name
+                    }
+                    default:
+                        throw new UnsupportedOperationException("Unsupported expression type of " +
+                            expr.feature.eClass.name)
+                }
 
-				if (right == "None")
-					right = "NONE"
-				var receiver = generateExpression(expr.receiver, iflvl)
-				if (receiver === null) {
-					'''«right»'''
-				} else {
-					'''_resolve_rosetta_attr(«receiver», "«right»")'''
-				}
-			}
-			RosettaExistsExpression: {
-				val argument = expr.argument as RosettaExpression
-				'''((«generateExpression(argument, iflvl)») is not None)'''
-			}
-			RosettaBinaryOperation: {
-				binaryExpr(expr, iflvl)
-			}
-			RosettaAbsentExpression: {
-				val argument = expr.argument as RosettaExpression
-				'''((«generateExpression(argument, iflvl)») is None)'''
-			}
-			RosettaReference: {
-				reference(expr, iflvl)
-			}
-			RosettaNumberLiteral: {
-				'''«expr.value»'''
-			}
-			RosettaBooleanLiteral: {
-				if (expr.value == "true")
-					'''True'''
-				else
-					'''False'''
-			}
-			RosettaIntLiteral: {
-				'''«expr.value»'''
-			}
-			RosettaStringLiteral: {
-				'''"«expr.value»"'''
-			}
-			RosettaOnlyElement: {
-				val argument = expr.argument as RosettaExpression
-				'''get_only_element(«generateExpression(argument, iflvl)»)'''
-			}
-			RosettaEnumValueReference: {
-				val value = EnumHelper.convertValues(expr.value)
-				'''«expr.enumeration».«value»'''
-			}
-			RosettaOnlyExistsExpression: {
-				var aux = expr as RosettaOnlyExistsExpression;
-				'''self.check_one_of_constraint(self, «generateExpression(aux.getArgs().get(0), iflvl)»)'''
-			}
-			RosettaCountOperation: {
-				val argument = expr.argument as RosettaExpression
-				'''len(«generateExpression(argument, iflvl)»)'''
-			}
-			ListLiteral: {
-				'''[«FOR arg : expr.elements SEPARATOR ', '»«generateExpression(arg, iflvl)»«ENDFOR»]'''
-			}
+                if (right == "None")
+                    right = "NONE"
+                var receiver = generateExpression(expr.receiver, iflvl)
+                if (receiver === null) {
+                    '''«right»'''
+                } else {
+                    '''_resolve_rosetta_attr(«receiver», "«right»")'''
+                }
+            }
+            RosettaExistsExpression: {
+                val argument = expr.argument as RosettaExpression
+                '''((«generateExpression(argument, iflvl)») is not None)'''
+            }
+            RosettaBinaryOperation: {
+                binaryExpr(expr, iflvl)
+            }
+            RosettaAbsentExpression: {
+                val argument = expr.argument as RosettaExpression
+                '''((«generateExpression(argument, iflvl)») is None)'''
+            }
+            RosettaReference: {
+                reference(expr, iflvl)
+            }
+            RosettaNumberLiteral: {
+                '''«expr.value»'''
+            }
+            RosettaBooleanLiteral: {
+                if (expr.value == "true")
+                    '''True'''
+                else
+                    '''False'''
+            }
+            RosettaIntLiteral: {
+                '''«expr.value»'''
+            }
+            RosettaStringLiteral: {
+                '''"«expr.value»"'''
+            }
+            RosettaOnlyElement: {
+                val argument = expr.argument as RosettaExpression
+                '''get_only_element(«generateExpression(argument, iflvl)»)'''
+            }
+            RosettaEnumValueReference: {
+                val value = EnumHelper.convertValues(expr.value)
+                '''«expr.enumeration».«value»'''
+            }
+            RosettaOnlyExistsExpression: {
+                var aux = expr as RosettaOnlyExistsExpression;
+                '''self.check_one_of_constraint(self, «generateExpression(aux.getArgs().get(0), iflvl)»)'''
+            }
+            RosettaCountOperation: {
+                val argument = expr.argument as RosettaExpression
+                '''len(«generateExpression(argument, iflvl)»)'''
+            }
+            ListLiteral: {
+                '''[«FOR arg : expr.elements SEPARATOR ', '»«generateExpression(arg, iflvl)»«ENDFOR»]'''
+            }
 
-			DistinctOperation: {
+            DistinctOperation: {
             // Implement the logic for DistinctOperation
             // Example: return '''set(«generateExpression(expr.argument, iflvl)»)'''
-	            val argument = generateExpression(expr.argument, iflvl);
-	    		return '''set(«argument»)''';
-	        }
-	        
-	        SortOperation: {
-	        	val argument = generateExpression(expr.argument, iflvl);
-    			return '''sorted(«argument»)''';
+                val argument = generateExpression(expr.argument, iflvl);
+                return '''set(«argument»)''';
+            }
+            
+            SortOperation: {
+                val argument = generateExpression(expr.argument, iflvl);
+                return '''sorted(«argument»)''';
             // Implement the logic for DistinctOperation
             // Example: return '''set(«generateExpression(expr.argument, iflvl)»)'''
-	        }
-	        ThenOperation: {
-			    val funcExpr = expr.function
-			    val argExpr = generateExpression(expr.argument, iflvl)
-			    val body = generateExpression(funcExpr.body, iflvl)
-			    val funcParams = funcExpr.parameters.map[it.name].join(", ")
-			
-			    // Handling the case where funcParams is empty
-			    val lambdaFunction = if (funcParams.empty) {
-			        '''(lambda item: «body»)'''
-			    } else {
-			        '''(lambda «funcParams»: «body»)'''
-			    }
-			
-			    // Using the lambda function. If there are no parameters, argExpr will not be used.
-			    return '''«lambdaFunction»(«argExpr»)'''
-			}
-	        LastOperation: {
-	            // Implement the logic for LastOperation
-	            // Example: return '''«generateExpression(expr.argument, iflvl)»[-1]'''
-	            val argument = generateExpression(expr.argument, iflvl);
-			    // Assuming argument is a list from which we want the last item
-			    return '''«argument»[-1]''';
-	        }
-	        SumOperation: {
-	            // Implement the logic for SumOperation
-	            // Example: return '''sum(«generateExpression(expr.argument, iflvl)»)'''
-	            val argument = generateExpression(expr.argument, iflvl);
-			    // Assuming argument is a list of numbers we want to sum
-			    return '''sum(«argument»)''';
-	        }
-	        FirstOperation: {
-	            // Implement the logic for FirstOperation
-	            // Example: return '''«generateExpression(expr.argument, iflvl)»[0]'''
-	            val argument = generateExpression(expr.argument, iflvl);
-			    // Assuming argument is a list from which we want the first item
-			    return '''«argument»[0]''';
-	        }
-	        FilterOperation: {
-			    // Generate the expression for the list to be filtered
-			    val argument = generateExpression(expr.argument, iflvl);
-			
-			    // Generate the boolean expression for filtering
-			    val filterExpression = generateExpression(expr.function.body, iflvl);
-			
-			    // Construct the call to the rosetta_filter function in Python
-			    // Assuming rosetta_filter is defined in your Python environment
-			    val filterCall = "rosetta_filter(" + argument + ", lambda item: " + filterExpression + ")";
-			
-			    // Return the filter function call
-			    return filterCall;
-			}
+            }
+            ThenOperation: {
+                val funcExpr = expr.function
+                val argExpr = generateExpression(expr.argument, iflvl)
+                val body = generateExpression(funcExpr.body, iflvl)
+                val funcParams = funcExpr.parameters.map[it.name].join(", ")
+            
+                // Handling the case where funcParams is empty
+                val lambdaFunction = if (funcParams.empty) {
+                    '''(lambda item: «body»)'''
+                } else {
+                    '''(lambda «funcParams»: «body»)'''
+                }
+            
+                // Using the lambda function. If there are no parameters, argExpr will not be used.
+                return '''«lambdaFunction»(«argExpr»)'''
+            }
+            LastOperation: {
+                // Implement the logic for LastOperation
+                // Example: return '''«generateExpression(expr.argument, iflvl)»[-1]'''
+                val argument = generateExpression(expr.argument, iflvl);
+                // Assuming argument is a list from which we want the last item
+                return '''«argument»[-1]''';
+            }
+            SumOperation: {
+                // Implement the logic for SumOperation
+                // Example: return '''sum(«generateExpression(expr.argument, iflvl)»)'''
+                val argument = generateExpression(expr.argument, iflvl);
+                // Assuming argument is a list of numbers we want to sum
+                return '''sum(«argument»)''';
+            }
+            FirstOperation: {
+                // Implement the logic for FirstOperation
+                // Example: return '''«generateExpression(expr.argument, iflvl)»[0]'''
+                val argument = generateExpression(expr.argument, iflvl);
+                // Assuming argument is a list from which we want the first item
+                return '''«argument»[0]''';
+            }
+            FilterOperation: {
+                // Generate the expression for the list to be filtered
+                val argument = generateExpression(expr.argument, iflvl);
+            
+                // Generate the boolean expression for filtering
+                val filterExpression = generateExpression(expr.function.body, iflvl);
+            
+                // Construct the call to the rosetta_filter function in Python
+                // Assuming rosetta_filter is defined in your Python environment
+                val filterCall = "rosetta_filter(" + argument + ", lambda item: " + filterExpression + ")";
+            
+                // Return the filter function call
+                return filterCall;
+            }
 
-	        MapOperation: {
-			    val inlineFunc = expr.function as InlineFunction;
-			    val funcParameters = inlineFunc.parameters.map[it.name].join(", ");
-			    val funcBody = generateExpression(inlineFunc.body, iflvl);
-			    // Construct the Python lambda function
-			    val lambdaFunction = "lambda item: " + funcBody;
-			    
-			    val argument = generateExpression(expr.argument, iflvl);
-			    // Using map function with the lambda
-			    val pythonMapOperation = "map(" + lambdaFunction + ", " + argument + ")";
-			    
-			    return pythonMapOperation;
-			}
-			AsKeyOperationImpl: {
-	            // Assuming AsKeyOperationImpl has a 'key' (possibly the 'operator' attribute) and an 'argument' property
-	            val key = expr.operator // or another property representing the key
-	            val argument = generateExpression(expr.argument, iflvl)
-	
-	            return '''{«key»: «argument»}''' // Example: creating a dictionary entry in Python
-	        }
-	        FlattenOperation: {
-			    val nestedListExpr = generateExpression(expr.argument, iflvl)
-			    // Using the custom flatten_list method
-			    return '''flatten_list(«nestedListExpr»)'''
-			}
-	        RosettaConstructorExpression: {
-			    val type = expr.typeCall?.type?.name // Get the type name, if available
-			    val keyValuePairs = expr.values // Get the key-value pairs from the constructor expression
-			
-			    val pythonConstructor = if (type !== null) {
-			        // If a type name is available, assume a custom Python class with a constructor
-			        '''«type»(«FOR pair : keyValuePairs SEPARATOR ', '»«pair.key.name»=«generateExpression(pair.value, iflvl)»«ENDFOR»)'''
-			    } else {
-			        // If no type name is available, assume a dictionary
-			        '''{«FOR pair : keyValuePairs SEPARATOR ', '»'«pair.key.name»': «generateExpression(pair.value, iflvl)»«ENDFOR»}'''
-			    }
-			
-			    return pythonConstructor
-			}
-	        
-			default:
-				throw new UnsupportedOperationException("Unsupported expression type of " + expr?.class?.simpleName)
-		}
-	}
+            MapOperation: {
+                val inlineFunc = expr.function as InlineFunction;
+                val funcParameters = inlineFunc.parameters.map[it.name].join(", ");
+                val funcBody = generateExpression(inlineFunc.body, iflvl);
+                // Construct the Python lambda function
+                val lambdaFunction = "lambda item: " + funcBody;
+                
+                val argument = generateExpression(expr.argument, iflvl);
+                // Using map function with the lambda
+                val pythonMapOperation = "map(" + lambdaFunction + ", " + argument + ")";
+                
+                return pythonMapOperation;
+            }
+            AsKeyOperationImpl: {
+                // Assuming AsKeyOperationImpl has a 'key' (possibly the 'operator' attribute) and an 'argument' property
+                val key = expr.operator // or another property representing the key
+                val argument = generateExpression(expr.argument, iflvl)
+    
+                return '''{«key»: «argument»}''' // Example: creating a dictionary entry in Python
+            }
+            FlattenOperation: {
+                val nestedListExpr = generateExpression(expr.argument, iflvl)
+                // Using the custom flatten_list method
+                return '''flatten_list(«nestedListExpr»)'''
+            }
+            RosettaConstructorExpression: {
+                val type = expr.typeCall?.type?.name // Get the type name, if available
+                val keyValuePairs = expr.values // Get the key-value pairs from the constructor expression
+            
+                val pythonConstructor = if (type !== null) {
+                    // If a type name is available, assume a custom Python class with a constructor
+                    '''«type»(«FOR pair : keyValuePairs SEPARATOR ', '»«pair.key.name»=«generateExpression(pair.value, iflvl)»«ENDFOR»)'''
+                } else {
+                    // If no type name is available, assume a dictionary
+                    '''{«FOR pair : keyValuePairs SEPARATOR ', '»'«pair.key.name»': «generateExpression(pair.value, iflvl)»«ENDFOR»}'''
+                }
+            
+                return pythonConstructor
+            }
+            
+            default:
+                throw new UnsupportedOperationException("Unsupported expression type of " + expr?.class?.simpleName)
+        }
+    }
 
-	protected def String reference(RosettaReference expr, int iflvl) {
-		switch (expr) {
-			RosettaImplicitVariable: {
-				'''«expr.name»'''	
-			}
-			RosettaSymbolReference: {
-				symbolReference(expr, iflvl)
-			}
-		}
-	}
+    protected def String reference(RosettaReference expr, int iflvl) {
+        switch (expr) {
+            RosettaImplicitVariable: {
+                '''«expr.name»'''	
+            }
+            RosettaSymbolReference: {
+                symbolReference(expr, iflvl)
+            }
+        }
+    }
 
-	def String symbolReference(RosettaSymbolReference expr, int iflvl) {
-		val s = expr.symbol
-		
-		switch (s) {
-			Data: {
-				'''«s.name»'''
-			}
-			Attribute: {
-				'''_resolve_rosetta_attr(self, "«s.name»")'''
-			}
-			RosettaEnumeration: {
-				'''«s.name»'''
-			}
-			RosettaCallableWithArgs: {
-				callableWithArgsCall(s, expr, iflvl)
-			}
-			ShortcutDeclaration:{
-				'''_resolve_rosetta_attr(self, "«s.name»")'''
-			}			
-			ClosureParameter:{
-				'''_resolve_rosetta_attr(self, "«s.name»")'''
-			}
-			
-			default:
-				throw new UnsupportedOperationException("Unsupported callable type of " + s.class.simpleName)
-		}
-	}
+    def String symbolReference(RosettaSymbolReference expr, int iflvl) {
+        val s = expr.symbol
+        
+        switch (s) {
+            Data: {
+                '''«s.name»'''
+            }
+            Attribute: {
+                '''_resolve_rosetta_attr(self, "«s.name»")'''
+            }
+            RosettaEnumeration: {
+                '''«s.name»'''
+            }
+            RosettaCallableWithArgs: {
+                callableWithArgsCall(s, expr, iflvl)
+            }
+            ShortcutDeclaration:{
+                '''_resolve_rosetta_attr(self, "«s.name»")'''
+            }			
+            ClosureParameter:{
+                '''_resolve_rosetta_attr(self, "«s.name»")'''
+            }
+            
+            default:
+                throw new UnsupportedOperationException("Unsupported callable type of " + s.class.simpleName)
+        }
+    }
 
-	def String callableWithArgsCall(RosettaCallableWithArgs s, RosettaSymbolReference expr, int iflvl) {
-		if (s instanceof FunctionImpl)
-			addImportsFromConditions(s.getName(), (s.eContainer as RosettaModel).name + "." + "functions")
-		else
-			addImportsFromConditions(s.name, (s.eContainer as RosettaModel).name)
-		var args = '''«FOR arg : expr.args SEPARATOR ', '»«generateExpression(arg, iflvl)»«ENDFOR»'''
-		'''«s.name»(«args»)'''
+    def String callableWithArgsCall(RosettaCallableWithArgs s, RosettaSymbolReference expr, int iflvl) {
+        if (s instanceof FunctionImpl)
+            addImportsFromConditions(s.getName(), (s.eContainer as RosettaModel).name + "." + "functions")
+        else
+            addImportsFromConditions(s.name, (s.eContainer as RosettaModel).name)
+        var args = '''«FOR arg : expr.args SEPARATOR ', '»«generateExpression(arg, iflvl)»«ENDFOR»'''
+        '''«s.name»(«args»)'''
 
-	}
+    }
 
-	def String binaryExpr(RosettaBinaryOperation expr, int iflvl) {
-		if (expr instanceof ModifiableBinaryOperation) {
-			if (expr.cardMod !== null) {
-				if (expr.operator == "<>") {
-					'''any_elements(«generateExpression(expr.left, iflvl)», "«expr.operator»", «generateExpression(expr.right, iflvl)»)'''
-				} else {
-					'''all_elements(«generateExpression(expr.left, iflvl)», "«expr.operator»", «generateExpression(expr.right, iflvl)»)'''
-				}
-			}
-		} else {
-			switch expr.operator {
-				case ("="): {
-					'''(«generateExpression(expr.left, iflvl)» == «generateExpression(expr.right, iflvl)»)'''
-				}
-				case ("<>"): {
-					'''(«generateExpression(expr.left, iflvl)» != «generateExpression(expr.right, iflvl)»)'''
-				}
-				case ("contains"): {
-					'''contains(«generateExpression(expr.left, iflvl)», «generateExpression(expr.right, iflvl)»)'''
+    def String binaryExpr(RosettaBinaryOperation expr, int iflvl) {
+        if (expr instanceof ModifiableBinaryOperation) {
+            if (expr.cardMod !== null) {
+                if (expr.operator == "<>") {
+                    '''any_elements(«generateExpression(expr.left, iflvl)», "«expr.operator»", «generateExpression(expr.right, iflvl)»)'''
+                } else {
+                    '''all_elements(«generateExpression(expr.left, iflvl)», "«expr.operator»", «generateExpression(expr.right, iflvl)»)'''
+                }
+            }
+        } else {
+            switch expr.operator {
+                case ("="): {
+                    '''(«generateExpression(expr.left, iflvl)» == «generateExpression(expr.right, iflvl)»)'''
+                }
+                case ("<>"): {
+                    '''(«generateExpression(expr.left, iflvl)» != «generateExpression(expr.right, iflvl)»)'''
+                }
+                case ("contains"): {
+                    '''contains(«generateExpression(expr.left, iflvl)», «generateExpression(expr.right, iflvl)»)'''
 
-				}
-				case ("disjoint"): {
-					'''disjoint(«generateExpression(expr.left, iflvl)», «generateExpression(expr.right, iflvl)»)'''
+                }
+                case ("disjoint"): {
+                    '''disjoint(«generateExpression(expr.left, iflvl)», «generateExpression(expr.right, iflvl)»)'''
 
-				}
-				case ("join"): {
-					'''join(«generateExpression(expr.left, iflvl)», «generateExpression(expr.right, iflvl)»)'''
-				}
-				default: {
-					'''(«generateExpression(expr.left, iflvl)» «expr.operator» «generateExpression(expr.right, iflvl)»)'''
-				}
-			}
-		}
-	}
+                }
+                case ("join"): {
+                    '''join(«generateExpression(expr.left, iflvl)», «generateExpression(expr.right, iflvl)»)'''
+                }
+                default: {
+                    '''(«generateExpression(expr.left, iflvl)» «expr.operator» «generateExpression(expr.right, iflvl)»)'''
+                }
+            }
+        }
+    }
 
-	def addImportsFromConditions(String variable, String namespace) {
-		val import = '''from «namespace».«variable» import «variable»'''
-		if(importsFound!=null){
-			if (!importsFound.contains(import)) {
-				importsFound.add(import)
-			}
-		}
-	}
+    def addImportsFromConditions(String variable, String namespace) {
+        val import = '''from «namespace».«variable» import «variable»'''
+        if(importsFound!=null){
+            if (!importsFound.contains(import)) {
+                importsFound.add(import)
+            }
+        }
+    }
 }

--- a/python/src/main/java/com/regnosys/rosetta/generator/python/func/PythonFunctionGenerator.xtend
+++ b/python/src/main/java/com/regnosys/rosetta/generator/python/func/PythonFunctionGenerator.xtend
@@ -45,22 +45,26 @@ class  PythonFunctionGenerator {
     val Object SymbolReference = null
     
     static def toPythonBasicType(String typename) {
-        switch typename {
-           case 'string': 'str'
-            case 'time': 'datetime.time'
-            case 'date': 'datetime.date'
-            case 'dateTime': 'datetime.datetime'
-            case 'zonedDateTime': 'datetime.datetime'
-            case 'number': 'Decimal'
-            case 'boolean': 'bool'
-            case 'int': 'int'
-            case 'calculation',				
-            case 'productType',				
-            case 'eventType':
-                'str'
+        switch (typename) {
+            case 'string', 
+            case 'eventType',
+            case 'calculation',
+            case 'productType':				
+                return 'str'
+            case 'time',
+            case 'date': 
+                return 'datetime.date'
+            case 'dateTime',
+            case 'zonedDateTime':
+                return 'datetime.datetime'
+            case 'number': 
+                return 'Decimal'
+            case 'boolean': 
+                return 'bool'
+            case 'int': 
+                return 'int'
             default:
-                typename
-
+                return typename
         }
     }
     
@@ -143,7 +147,7 @@ class  PythonFunctionGenerator {
         if(output!=null){
             '''
             «IF function.operations.size==0 && function.getShortcuts().size==0»
-            «output.name» = _resolve_rosetta_attr(self, "«output.name»")
+                «output.name» = _resolve_rosetta_attr(self, "«output.name»")
             «ENDIF»
             
             «generatePostConditions(function)»
@@ -189,14 +193,14 @@ class  PythonFunctionGenerator {
         Parameters 
         ----------
         «FOR input : inputs SEPARATOR '\n'»
-        «input.getName» : «input.getTypeCall().getType().getName()»
-        «input.getDefinition()»
+            «input.getName» : «input.getTypeCall().getType().getName()»
+            «input.getDefinition()»
         «ENDFOR»
         
         Returns
         -------
         «IF output !== null»
-        «output.getName()» : «output.getTypeCall().getType().getName()»
+            «output.getName()» : «output.getTypeCall().getType().getName()»
         «ELSE»
         No Return
         «ENDIF»
@@ -210,15 +214,15 @@ class  PythonFunctionGenerator {
     
         // Add dependencies from shortcuts and operations
         func.shortcuts.forEach[shortcut |
-            dependencies.addAll(functionDependencyProvider.dependencies(shortcut.expression))
+            dependencies.addAll(functionDependencyProvider.findDependencies(shortcut.expression))
         ]
         func.operations.forEach[operation |
-            dependencies.addAll(functionDependencyProvider.dependencies(operation.expression))
+            dependencies.addAll(functionDependencyProvider.findDependencies(operation.expression))
         ]
     
         // Add dependencies from conditions and post conditions
         (func.conditions + func.postConditions).forEach[condition |
-            dependencies.addAll(functionDependencyProvider.dependencies(condition.expression))
+            dependencies.addAll(functionDependencyProvider.findDependencies(condition.expression))
         ]
     
         // Add dependencies from input types
@@ -241,10 +245,10 @@ class  PythonFunctionGenerator {
     
         ''' 
         «FOR shortcut : function.shortcuts »
-        «expressionGenerator.generateExpressionThenElse(shortcut.expression, levelList)»
+            «expressionGenerator.generateExpressionThenElse(shortcut.expression, levelList)»
         «ENDFOR»
         «FOR opeartion : function.operations »
-        «expressionGenerator.generateExpressionThenElse(opeartion.expression, levelList)»
+            «expressionGenerator.generateExpressionThenElse(opeartion.expression, levelList)»
         «ENDFOR»
         '''
     }
@@ -254,7 +258,6 @@ class  PythonFunctionGenerator {
         «IF function.conditions.size>0»
         # conditions
         «expressionGenerator.generateConditions(function.conditions)»
-        
         # Execute all registered conditions
         execute_conditions(self)
         «ENDIF»
@@ -265,8 +268,7 @@ class  PythonFunctionGenerator {
         '''     
         «IF function.postConditions.size>0»
         # post-conditions
-        «expressionGenerator.generatePostConditions(function.postConditions)»
-        
+            «expressionGenerator.generatePostConditions(function.postConditions)»
         # Execute all registered post-conditions
         execute_post_conditions(self)
         «ENDIF»

--- a/python/src/main/java/com/regnosys/rosetta/generator/python/object/PythonMetaFieldGenerator.xtend
+++ b/python/src/main/java/com/regnosys/rosetta/generator/python/object/PythonMetaFieldGenerator.xtend
@@ -19,7 +19,7 @@ class PythonMetaFieldGenerator {
 
         val refs = rosettaClasses
                 .flatMap[expandedAttributes]
- 				.filter[hasMetas && metas.exists[name=="reference" || name=="address"]]
+                 .filter[hasMetas && metas.exists[name=="reference" || name=="address"]]
                 .map[type]
                 .toSet
 
@@ -49,14 +49,14 @@ class PythonMetaFieldGenerator {
 
     private def generateMetaFieldsImports() 
     '''
-	'''
+    '''
 
     private def generateFieldWithMeta(ExpandedType type) '''
     class FieldWithMeta«type.toMetaTypeName»:
         «generateAttribute(type)»
         meta = MetaFields()
 
-	'''
+    '''
 
     private def generateAttribute(ExpandedType type) {
         if (type.enumeration) {
@@ -74,7 +74,7 @@ class PythonMetaFieldGenerator {
         externalReference = None
         address = Reference()
 
-	'''
+    '''
     private def generateBasicReferenceWithMeta(ExpandedType type)
     '''
     class BasicReferenceWithMeta«type.toMetaTypeName»:
@@ -83,7 +83,7 @@ class PythonMetaFieldGenerator {
         externalReference = None
         address = Reference()
 
-	'''
+    '''
 
     private def genMetaFields(Iterable<RosettaMetaType> types, String version) 
     '''
@@ -111,5 +111,5 @@ class PythonMetaFieldGenerator {
         scope = None
         value = None
 
-	'''
+    '''
 }

--- a/python/src/main/java/com/regnosys/rosetta/generator/python/object/PythonModelObjectBoilerPlate.xtend
+++ b/python/src/main/java/com/regnosys/rosetta/generator/python/object/PythonModelObjectBoilerPlate.xtend
@@ -10,7 +10,7 @@ class PythonModelObjectBoilerPlate {
     def toAttributeName(ExpandedAttribute attribute) {
         if (attribute.name == "val")
         '''`val`'''
-		else
+        else
         attribute.name.toFirstLower
     }
 
@@ -25,9 +25,9 @@ class PythonModelObjectBoilerPlate {
     def toType(ExpandedAttribute attribute) {
         if (attribute.multiple)
             '''MutableList<«attribute.toRawType»>'''
-		else if (attribute.singleOptional)
+        else if (attribute.singleOptional)
             '''«attribute.toRawType»'''
-		else
+        else
         '''«attribute.toRawType»'''
     }
 

--- a/python/src/main/java/com/regnosys/rosetta/generator/python/object/PythonModelObjectGenerator.xtend
+++ b/python/src/main/java/com/regnosys/rosetta/generator/python/object/PythonModelObjectGenerator.xtend
@@ -48,251 +48,251 @@ import com.regnosys.rosetta.generator.python.expressions.PythonExpressionGenerat
 
 class PythonModelObjectGenerator {
 
-	@Inject extension RosettaExtensions
-	@Inject extension PythonModelObjectBoilerPlate
+    @Inject extension RosettaExtensions
+    @Inject extension PythonModelObjectBoilerPlate
 
-	@Inject
-	PythonModelGeneratorUtil utils;
-	
-	@Inject
-	PythonExpressionGenerator expressionGenerator;
+    @Inject
+    PythonModelGeneratorUtil utils;
+    
+    @Inject
+    PythonExpressionGenerator expressionGenerator;
 
-	var List<String> importsFound = newArrayList
-	var if_cond_blocks = new ArrayList<String>()
+    var List<String> importsFound = newArrayList
+    var if_cond_blocks = new ArrayList<String>()
 
-	static def toPythonBasicType(ExpandedAttribute attribute) {
-		val typename = attribute.type.name;
-		switch typename {
-			case 'string':
-				'str'
-			case 'time':
-				'datetime.time'
-			case 'date':
-				'datetime.date'
-			case 'dateTime':
-				'datetime.datetime'
-			case 'zonedDateTime':
-				'datetime.datetime'
-			case 'number':
-				'Decimal'
-			case 'boolean':
-				'bool'
-			case 'int':
-				'int'
-			case 'calculation',
-			case 'productType',
-			case 'eventType':
-				'str'
-			default:
-				// (typename === null) ? null : typename.toFirstUpper
-				if (typename === null) {
-					return null;
-				}
-				else {
-					val nm = typename.toFirstUpper;
-					return attribute.type.model.name + '.' + nm + '.' + nm;
-				}
-		}
-	}
+    static def toPythonBasicType(ExpandedAttribute attribute) {
+        val typename = attribute.type.name;
+        switch typename {
+            case 'string':
+                'str'
+            case 'time':
+                'datetime.time'
+            case 'date':
+                'datetime.date'
+            case 'dateTime':
+                'datetime.datetime'
+            case 'zonedDateTime':
+                'datetime.datetime'
+            case 'number':
+                'Decimal'
+            case 'boolean':
+                'bool'
+            case 'int':
+                'int'
+            case 'calculation',
+            case 'productType',
+            case 'eventType':
+                'str'
+            default:
+                // (typename === null) ? null : typename.toFirstUpper
+                if (typename === null) {
+                    return null;
+                }
+                else {
+                    val nm = typename.toFirstUpper;
+                    return attribute.type.model.name + '.' + nm + '.' + nm;
+                }
+        }
+    }
 
-	static def toPythonType(Data c, ExpandedAttribute attribute) throws Exception {
-		// var basicType = toPythonBasicType(attribute.type.name);
-		var basicType = toPythonBasicType(attribute);
-		if (basicType === null) {
-			throw new Exception("Attribute type is null for " + attribute.name + " for class " + c.name)
-		}
-		if (attribute.hasMetas) {
-			var helper_class = "Attribute";
-			var is_ref = false;
-			var is_address = false;
-			var is_meta = false;
-			for (ExpandedAttribute meta : attribute.getMetas()) {
-				val mname = meta.getName();
-				if (mname == "reference") { // what about location?!?
-					is_ref = true;
-				} else if (mname == "address") {
-					is_address = true;
-				} else if (mname == "key" || mname == "id" || mname == "scheme" || mname == "location") {
-					is_meta = true;
-				} else {
-					helper_class += "---" + mname + "---";
-				}
-			}
-			if (is_meta) {
-				helper_class += "WithMeta";
-			}
-			if (is_address) {
-				helper_class += "WithAddress";
-			}
-			if (is_ref) {
-				helper_class += "WithReference";
-			}
-			if (is_meta || is_address) {
-				helper_class += "[" + basicType + "]";
-			}
+    static def toPythonType(Data c, ExpandedAttribute attribute) throws Exception {
+        // var basicType = toPythonBasicType(attribute.type.name);
+        var basicType = toPythonBasicType(attribute);
+        if (basicType === null) {
+            throw new Exception("Attribute type is null for " + attribute.name + " for class " + c.name)
+        }
+        if (attribute.hasMetas) {
+            var helper_class = "Attribute";
+            var is_ref = false;
+            var is_address = false;
+            var is_meta = false;
+            for (ExpandedAttribute meta : attribute.getMetas()) {
+                val mname = meta.getName();
+                if (mname == "reference") { // what about location?!?
+                    is_ref = true;
+                } else if (mname == "address") {
+                    is_address = true;
+                } else if (mname == "key" || mname == "id" || mname == "scheme" || mname == "location") {
+                    is_meta = true;
+                } else {
+                    helper_class += "---" + mname + "---";
+                }
+            }
+            if (is_meta) {
+                helper_class += "WithMeta";
+            }
+            if (is_address) {
+                helper_class += "WithAddress";
+            }
+            if (is_ref) {
+                helper_class += "WithReference";
+            }
+            if (is_meta || is_address) {
+                helper_class += "[" + basicType + "]";
+            }
 
-			basicType = helper_class + " | " + basicType;
-		}
-		return basicType
-	}
+            basicType = helper_class + " | " + basicType;
+        }
+        return basicType
+    }
 
-	def Map<String, ? extends CharSequence> generate(
-		Iterable<Data> rosettaClasses,
-		Iterable<RosettaMetaType> metaTypes,
-		String version
-	) {
-		val result = new HashMap
+    def Map<String, ? extends CharSequence> generate(
+        Iterable<Data> rosettaClasses,
+        Iterable<RosettaMetaType> metaTypes,
+        String version
+    ) {
+        val result = new HashMap
 
-		for (Data type : rosettaClasses) {
-			val model = type.eContainer as RosettaModel
-			val classes = type.generateClasses(version).replaceTabsWithSpaces
-			result.put(utils.toPyFileName(model.name, type.name), utils.createImports(type.name) + classes)
-		}
+        for (Data type : rosettaClasses) {
+            val model = type.eContainer as RosettaModel
+            val classes = type.generateClasses(version).replaceTabsWithSpaces
+            result.put(utils.toPyFileName(model.name, type.name), utils.createImports(type.name) + classes)
+        }
 
-		result;
-	}
+        result;
+    }
 
-	def boolean checkBasicType(ExpandedAttribute attr) {
-		val types = Arrays.asList('int', 'str', 'Decimal', 'date', 'datetime', 'datetime.datetime', 'datetime.date', 'datetime.time', 'time',
-			'bool', 'number')
-		return (attr !== null && attr.toRawType !== null) ? types.contains(attr.toRawType.toString()) : false
-	}
+    def boolean checkBasicType(ExpandedAttribute attr) {
+        val types = Arrays.asList('int', 'str', 'Decimal', 'date', 'datetime', 'datetime.datetime', 'datetime.date', 'datetime.time', 'time',
+            'bool', 'number')
+        return (attr !== null && attr.toRawType !== null) ? types.contains(attr.toRawType.toString()) : false
+    }
 
-	def boolean checkBasicType(String attr) {
-		val types = Arrays.asList('int', 'str', 'Decimal', 'date', 'datetime', 'datetime.datetime', 'datetime.date', 'datetime.time', 'time',
-			'bool', 'number')
-		return types.contains(attr)
-	}
+    def boolean checkBasicType(String attr) {
+        val types = Arrays.asList('int', 'str', 'Decimal', 'date', 'datetime', 'datetime.datetime', 'datetime.date', 'datetime.time', 'time',
+            'bool', 'number')
+        return types.contains(attr)
+    }
 
-	/**
-	 * Generate the classes
-	 */
-	// TODO remove Date implementation in beginning
-	// TODO removed one-of condition due to limitations after instantiation of objects
-	private def generateClasses(Data rosettaClass, String version) {
-		var List<String> enumImports = newArrayList
-		var List<String> dataImports = newArrayList
-		var List<String> classDefinitions = newArrayList
-		// var List<String> updateForwardRefs = newArrayList
-		var superType = rosettaClass.superType
-		if (superType !== null && superType.name === null) {
-			throw new Exception("SuperType is null for " + rosettaClass.name)
-		}
-		importsFound = getImportsFromAttributes(rosettaClass)
-		expressionGenerator.importsFound = this.importsFound;
-		val classDefinition = generateClassDefinition(rosettaClass)
-		classDefinitions.add(classDefinition)
-		// updateForwardRefs.add('''«rosettaClass.name».update_forward_refs()''')
+    /**
+     * Generate the classes
+     */
+    // TODO remove Date implementation in beginning
+    // TODO removed one-of condition due to limitations after instantiation of objects
+    private def generateClasses(Data rosettaClass, String version) {
+        var List<String> enumImports = newArrayList
+        var List<String> dataImports = newArrayList
+        var List<String> classDefinitions = newArrayList
+        // var List<String> updateForwardRefs = newArrayList
+        var superType = rosettaClass.superType
+        if (superType !== null && superType.name === null) {
+            throw new Exception("SuperType is null for " + rosettaClass.name)
+        }
+        importsFound = getImportsFromAttributes(rosettaClass)
+        expressionGenerator.importsFound = this.importsFound;
+        val classDefinition = generateClassDefinition(rosettaClass)
+        classDefinitions.add(classDefinition)
+        // updateForwardRefs.add('''«rosettaClass.name».update_forward_refs()''')
 
-		// Remove duplicates
-		enumImports = enumImports.toSet().toList()
-		dataImports = dataImports.toSet().toList()
+        // Remove duplicates
+        enumImports = enumImports.toSet().toList()
+        dataImports = dataImports.toSet().toList()
 
-		// Return generated classes
-		return '''
-			«IF superType!==null»from «(superType.eContainer as RosettaModel).name».«superType.name» import «superType.name»«ENDIF»
-			
-			«classDefinition»
-			
-			import cdm
-			«FOR dataImport : importsFound SEPARATOR "\n"»«dataImport»«ENDFOR»
-		'''
-		//	
-		// 	«FOR updateForwardRef : updateForwardRefs SEPARATOR "\n"»«updateForwardRef»«ENDFOR»
-		// '''
-	}
+        // Return generated classes
+        return '''
+            «IF superType!==null»from «(superType.eContainer as RosettaModel).name».«superType.name» import «superType.name»«ENDIF»
+            
+            «classDefinition»
+            
+            import cdm
+            «FOR dataImport : importsFound SEPARATOR "\n"»«dataImport»«ENDFOR»
+        '''
+        //	
+        // 	«FOR updateForwardRef : updateForwardRefs SEPARATOR "\n"»«updateForwardRef»«ENDFOR»
+        // '''
+    }
 
-	private def getImportsFromAttributes(Data rosettaClass) {
-		val filteredAttributes = rosettaClass.allExpandedAttributes.filter[enclosingType == rosettaClass.name].filter [
-			(it.name !== "reference") && (it.name !== "meta") && (it.name !== "scheme")
-		].filter[!checkBasicType(it)]
+    private def getImportsFromAttributes(Data rosettaClass) {
+        val filteredAttributes = rosettaClass.allExpandedAttributes.filter[enclosingType == rosettaClass.name].filter [
+            (it.name !== "reference") && (it.name !== "meta") && (it.name !== "scheme")
+        ].filter[!checkBasicType(it)]
 
-		val imports = newArrayList
-		for (attribute : filteredAttributes) {
-			// val originalIt = attribute
-			val model = attribute.type.model
-			if (model !== null) {
-				// val importStatement = '''from «model.name».«originalIt.toRawType» import «originalIt.toRawType»'''
-				val importStatement = '''import «model.name».«attribute.toRawType»'''
-				imports.add(importStatement)
-			}
-		}
+        val imports = newArrayList
+        for (attribute : filteredAttributes) {
+            // val originalIt = attribute
+            val model = attribute.type.model
+            if (model !== null) {
+                // val importStatement = '''from «model.name».«originalIt.toRawType» import «originalIt.toRawType»'''
+                val importStatement = '''import «model.name».«attribute.toRawType»'''
+                imports.add(importStatement)
+            }
+        }
 
-		// Remove duplicates by converting the list to a set and back to a list
-		return imports.toSet.toList
-	}
+        // Remove duplicates by converting the list to a set and back to a list
+        return imports.toSet.toList
+    }
 
-	private def generateClassDefinition(Data rosettaClass) {
-		return '''
-			class «rosettaClass.name»«IF rosettaClass.superType === null»«ENDIF»«IF rosettaClass.superType !== null»(«rosettaClass.superType.name»):«ELSE»(BaseDataClass):«ENDIF»
-				«IF rosettaClass.definition !== null»
-					"""
-					«rosettaClass.definition»
-					"""
-				«ENDIF»
-				«generateAttributes(rosettaClass)»
-				«expressionGenerator.generateConditions(rosettaClass)»
-		'''
-	}
+    private def generateClassDefinition(Data rosettaClass) {
+        return '''
+            class «rosettaClass.name»«IF rosettaClass.superType === null»«ENDIF»«IF rosettaClass.superType !== null»(«rosettaClass.superType.name»):«ELSE»(BaseDataClass):«ENDIF»
+                «IF rosettaClass.definition !== null»
+                    """
+                    «rosettaClass.definition»
+                    """
+                «ENDIF»
+                «generateAttributes(rosettaClass)»
+                «expressionGenerator.generateConditions(rosettaClass)»
+        '''
+    }
 
-	
-	private def generateAttributes(Data c) {
-		val attr = c.allExpandedAttributes.filter[enclosingType == c.name].filter [
-			(it.name !== "reference") && (it.name !== "meta") && (it.name !== "scheme")
-		]
-		val attrSize = attr.size()
-		val conditionsSize = c.conditions.size()
-		'''«IF attrSize === 0 && conditionsSize===0»pass«ELSE»«FOR attribute : attr SEPARATOR ""»«generateExpandedAttribute(c, attribute)»«ENDFOR»«ENDIF»'''
-	}
+    
+    private def generateAttributes(Data c) {
+        val attr = c.allExpandedAttributes.filter[enclosingType == c.name].filter [
+            (it.name !== "reference") && (it.name !== "meta") && (it.name !== "scheme")
+        ]
+        val attrSize = attr.size()
+        val conditionsSize = c.conditions.size()
+        '''«IF attrSize === 0 && conditionsSize===0»pass«ELSE»«FOR attribute : attr SEPARATOR ""»«generateExpandedAttribute(c, attribute)»«ENDFOR»«ENDIF»'''
+    }
 
-	private def generateExpandedAttribute(Data c, ExpandedAttribute attribute) {
-		var att = ""
-		if (attribute.sup > 1 || attribute.unbound) {
-			att += "List[" + toPythonType(c, attribute) + "]"
-		} else {
-			if (attribute.inf == 0) { // edge case (0..0) will come here
-				att += "Optional[" + toPythonType(c, attribute) + "]"
-			} else {
-				att += toPythonType(c, attribute) // cardinality (1..1)
-			}
-		}
+    private def generateExpandedAttribute(Data c, ExpandedAttribute attribute) {
+        var att = ""
+        if (attribute.sup > 1 || attribute.unbound) {
+            att += "List[" + toPythonType(c, attribute) + "]"
+        } else {
+            if (attribute.inf == 0) { // edge case (0..0) will come here
+                att += "Optional[" + toPythonType(c, attribute) + "]"
+            } else {
+                att += toPythonType(c, attribute) // cardinality (1..1)
+            }
+        }
 
-		var field_default = 'None'
-		if (attribute.inf == 1 && attribute.sup == 1)
-			field_default = '...' // mandatory field -> cardinality (1..1)
-		else if (attribute.sup > 1 || attribute.unbound) { // List filed of cardinality (m..n)
-			field_default = '[]'
-		}
+        var field_default = 'None'
+        if (attribute.inf == 1 && attribute.sup == 1)
+            field_default = '...' // mandatory field -> cardinality (1..1)
+        else if (attribute.sup > 1 || attribute.unbound) { // List filed of cardinality (m..n)
+            field_default = '[]'
+        }
 
-		var attrName        = (attribute.name == "global") ? "_global" : attribute.name
-		var need_card_check = !((attribute.inf == 0 && attribute.sup == 1) || 
-							    (attribute.inf == 1 && attribute.sup == 1) ||
-							    (attribute.inf == 0 && attribute.unbound))
+        var attrName        = (attribute.name == "global") ? "_global" : attribute.name
+        var need_card_check = !((attribute.inf == 0 && attribute.sup == 1) || 
+                                (attribute.inf == 1 && attribute.sup == 1) ||
+                                (attribute.inf == 0 && attribute.unbound))
 
 
-		var sup_str         = (attribute.unbound) ? 'None' : attribute.sup.toString()
- 		val attrDesc        = (attribute.definition === null) ? '' : attribute.definition.replaceAll('\\s+', ' ')
-		'''
-			«attrName»: «att» = Field(«field_default», description="«attrDesc»")
-			«IF attribute.definition !== null»
-				"""
-				«attribute.definition»
-				"""
-			«ENDIF»
-			«IF need_card_check»
-				@rosetta_condition
-				def cardinality_«attrName»(self):
-					return check_cardinality(self.«attrName», «attribute.inf», «sup_str»)
-				
-			«ENDIF»
-		'''
-	}
+        var sup_str         = (attribute.unbound) ? 'None' : attribute.sup.toString()
+         val attrDesc        = (attribute.definition === null) ? '' : attribute.definition.replaceAll('\\s+', ' ')
+        '''
+            «attrName»: «att» = Field(«field_default», description="«attrDesc»")
+            «IF attribute.definition !== null»
+                """
+                «attribute.definition»
+                """
+            «ENDIF»
+            «IF need_card_check»
+                @rosetta_condition
+                def cardinality_«attrName»(self):
+                    return check_cardinality(self.«attrName», «attribute.inf», «sup_str»)
+                
+            «ENDIF»
+        '''
+    }
 
-	def Iterable<ExpandedAttribute> allExpandedAttributes(Data type) {
-		type.allSuperTypes.map[it.expandedAttributes].flatten
-	}
+    def Iterable<ExpandedAttribute> allExpandedAttributes(Data type) {
+        type.allSuperTypes.map[it.expandedAttributes].flatten
+    }
 
-	def String definition(Data element) {
-		element.definition
-	}
+    def String definition(Data element) {
+        element.definition
+    }
 }

--- a/python/src/main/java/com/regnosys/rosetta/generator/python/util/PythonModelGeneratorUtil.xtend
+++ b/python/src/main/java/com/regnosys/rosetta/generator/python/util/PythonModelGeneratorUtil.xtend
@@ -7,105 +7,105 @@ import java.time.format.DateTimeFormatter
 class PythonModelGeneratorUtil {
     
     static def fileComment(String version) 
-		'''
-		 # This file is auto-generated from the ISDA Common Domain Model, do not edit.
-		 # Version: «version»
+        '''
+         # This file is auto-generated from the ISDA Common Domain Model, do not edit.
+         # Version: «version»
 
-		'''
+        '''
 
     static def comment(String definition) 
-		'''
-		«IF definition !==null && !definition.isEmpty »
-		# 
-		# «definition»
-		#
-		«ENDIF»
-		'''
+        '''
+        «IF definition !==null && !definition.isEmpty »
+        # 
+        # «definition»
+        #
+        «ENDIF»
+        '''
 
     static def classComment(String definition, Iterable<ExpandedAttribute> attributes) 
-		'''
-		«IF definition !==null && !definition.isEmpty »
-		#
-		# «definition»
-		#
-		 «FOR attribute : attributes»
-		 # @param «attribute.name» «attribute.definition»
-		 «ENDFOR»
-		#
-		«ENDIF»
-		'''
-		
-	def String createImports(String name){			
-		val imports=
-		'''
-		# pylint: disable=line-too-long, invalid-name, missing-function-docstring
-		# pylint: disable=bad-indentation, trailing-whitespace, superfluous-parens
-		# pylint: disable=wrong-import-position, unused-import, unused-wildcard-import
-		# pylint: disable=wildcard-import, wrong-import-order, missing-class-docstring
-		# pylint: disable=missing-module-docstring
-		from __future__ import annotations
-		from typing import List, Optional
-		import datetime
-		import inspect
-		from decimal import Decimal
-		from pydantic import Field
-		from rosetta.runtime.utils import (
-			BaseDataClass, rosetta_condition, _resolve_rosetta_attr
-		)
-		from rosetta.runtime.utils import *
-		
-		__all__ = [«"'"+name+"'"»]
-		
-		'''
-		imports
-	}
-		
-	def String createImportsFunc(String name) {			
-		val imports=
-		'''
-		# pylint: disable=line-too-long, invalid-name, missing-function-docstring, missing-module-docstring, superfluous-parens
-		# pylint: disable=wrong-import-position, unused-import, unused-wildcard-import, wildcard-import, wrong-import-order, missing-class-docstring
-		from __future__ import annotations
-		import datetime
-		import inspect
-		from decimal import Decimal
-		from abc import ABC, abstractmethod
-		from rosetta.runtime.utils import *
-		from rosetta.runtime.func_proxy import replaceable, create_module_attr_guardian
-		'''
-		imports
-	}
-	
-	def String toPyFileName(String namespace, String fileName) {
-		'''src/«namespace.replace(".", "/")»/«fileName».py''';
-	}
-	def String toPyFunctionFileName(String namespace, String fileName) {
-		'''src/«namespace.replace(".", "/")»/functions/«fileName».py''';
-	}
-	
-	def String createTopLevelInitFile (String version) {
-		return "from .version import __version__"
-	}
-	def String createVersionFile (String version) {
-		val versionComma	 = version.replace ('.', ',')
-		return "version = ("+versionComma+",0)\n"+
-		 	   "version_str = '"+version+"-0'\n"+
-		 	   "__version__ = '"+version+"'\n"+
-		 	   "__build_time__ = '"+LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)+"'"		 	
-	}
-	def String createPYProjectTomlFile (String version) {
-		return "[build-system]\n" + 
-			   "requires = [\"setuptools>=62.0\"]\n" +
-			   "build-backend = \"setuptools.build_meta\"\n\n" +
-			   "[project]\n" + 
-			   "name = \"python-cdm\"\n" + 
-			   "version = \"" + version + "\"\n" + 
-			   "requires-python = \">= 3.10\"\n" +
-			   "dependencies = [\n" + 
-			   "   \"pydantic>=2.6.1\",\n" +
-			   "   \"rosetta.runtime==3.0.0\"\n" +
-			   "]\n" +
-			   "[tool.setuptools.packages.find]\n" +
-			   "where = [\"src\"]"
-	}
+        '''
+        «IF definition !==null && !definition.isEmpty »
+        #
+        # «definition»
+        #
+         «FOR attribute : attributes»
+         # @param «attribute.name» «attribute.definition»
+         «ENDFOR»
+        #
+        «ENDIF»
+        '''
+        
+    def String createImports(String name){			
+        val imports=
+        '''
+        # pylint: disable=line-too-long, invalid-name, missing-function-docstring
+        # pylint: disable=bad-indentation, trailing-whitespace, superfluous-parens
+        # pylint: disable=wrong-import-position, unused-import, unused-wildcard-import
+        # pylint: disable=wildcard-import, wrong-import-order, missing-class-docstring
+        # pylint: disable=missing-module-docstring
+        from __future__ import annotations
+        from typing import List, Optional
+        import datetime
+        import inspect
+        from decimal import Decimal
+        from pydantic import Field
+        from rosetta.runtime.utils import (
+            BaseDataClass, rosetta_condition, _resolve_rosetta_attr
+        )
+        from rosetta.runtime.utils import *
+        
+        __all__ = [«"'"+name+"'"»]
+        
+        '''
+        imports
+    }
+        
+    def String createImportsFunc(String name) {			
+        val imports=
+        '''
+        # pylint: disable=line-too-long, invalid-name, missing-function-docstring, missing-module-docstring, superfluous-parens
+        # pylint: disable=wrong-import-position, unused-import, unused-wildcard-import, wildcard-import, wrong-import-order, missing-class-docstring
+        from __future__ import annotations
+        import datetime
+        import inspect
+        from decimal import Decimal
+        from abc import ABC, abstractmethod
+        from rosetta.runtime.utils import *
+        from rosetta.runtime.func_proxy import replaceable, create_module_attr_guardian
+        '''
+        imports
+    }
+    
+    def String toPyFileName(String namespace, String fileName) {
+        '''src/«namespace.replace(".", "/")»/«fileName».py''';
+    }
+    def String toPyFunctionFileName(String namespace, String fileName) {
+        '''src/«namespace.replace(".", "/")»/functions/«fileName».py''';
+    }
+    
+    def String createTopLevelInitFile (String version) {
+        return "from .version import __version__"
+    }
+    def String createVersionFile (String version) {
+        val versionComma	 = version.replace ('.', ',')
+        return "version = ("+versionComma+",0)\n"+
+                "version_str = '"+version+"-0'\n"+
+                "__version__ = '"+version+"'\n"+
+                "__build_time__ = '"+LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)+"'"		 	
+    }
+    def String createPYProjectTomlFile (String version) {
+        return "[build-system]\n" + 
+               "requires = [\"setuptools>=62.0\"]\n" +
+               "build-backend = \"setuptools.build_meta\"\n\n" +
+               "[project]\n" + 
+               "name = \"python-cdm\"\n" + 
+               "version = \"" + version + "\"\n" + 
+               "requires-python = \">= 3.10\"\n" +
+               "dependencies = [\n" + 
+               "   \"pydantic>=2.6.1\",\n" +
+               "   \"rosetta.runtime==3.0.0\"\n" +
+               "]\n" +
+               "[tool.setuptools.packages.find]\n" +
+               "where = [\"src\"]"
+    }
 }

--- a/python/src/main/java/com/regnosys/rosetta/generator/python/util/PythonTranslator.xtend
+++ b/python/src/main/java/com/regnosys/rosetta/generator/python/util/PythonTranslator.xtend
@@ -10,17 +10,17 @@ class PythonTranslator {
     static def toPythonBasicType(String typename) {
         switch typename {
            case 'string': 'str'
-			case 'time': 'datetime.time'
-			case 'date': 'datetime.date'
-			case 'dateTime': 'datetime.datetime'
-			case 'zonedDateTime': 'datetime.datetime'
-			case 'number': 'Decimal'
-			case 'boolean': 'bool'
-			case 'int': 'int'
-			case 'calculation',				
-			case 'productType',				
-			case 'eventType':
-				'str'
+            case 'time': 'datetime.time'
+            case 'date': 'datetime.date'
+            case 'dateTime': 'datetime.datetime'
+            case 'zonedDateTime': 'datetime.datetime'
+            case 'number': 'Decimal'
+            case 'boolean': 'bool'
+            case 'int': 'int'
+            case 'calculation',				
+            case 'productType',				
+            case 'eventType':
+                'str'
 
         }
 
@@ -32,12 +32,12 @@ class PythonTranslator {
             return basicType
         else if (type.enumeration)
             return '''«type.name.toFirstUpper»'''
-		else
+        else
         return type.name.toFirstUpper
     }
     
     def toPythonType(Attribute attr) {
- 		var type = attr.getTypeCall.type.name
+         var type = attr.getTypeCall.type.name
         val basicType = PythonTranslator.toPythonBasicType(type);
         if (basicType !== null)
             return basicType

--- a/python/src/main/java/com/regnosys/rosetta/generator/python/util/Util.xtend
+++ b/python/src/main/java/com/regnosys/rosetta/generator/python/util/Util.xtend
@@ -6,61 +6,61 @@ import java.util.NoSuchElementException
 import com.regnosys.rosetta.rosetta.RosettaType
 
 class Util {
-	
-	static def <T> Iterable<T> distinct(Iterable<T> parentIterable) {
-		return new DistinctByIterator(parentIterable, [it])
-	}
-	static def <T,U> Iterable<T> distinctBy(Iterable<T> parentIterable, Function<T,U> extractFunction) {
-		return new DistinctByIterator(parentIterable, extractFunction)
-	}
-	
-	def static <T> boolean exists(Iterable<? super T> iter, Class<T> clazz) {
-		!iter.filter(clazz).empty
-	}
-	
-	private static class DistinctByIterator<T, U> implements Iterable<T>{
-		val Iterable<T> iterable;
-		val Function<T,U> extractFunction;
-		
-		new(Iterable<T> iterable, Function<T,U> extractFunction) {
-			this.iterable = iterable
-			this.extractFunction = extractFunction
-		}
-		
-		override iterator() {
-			val parentIterator = iterable.iterator
-			return new Iterator<T>() {
-				val read = newHashSet
-				var T readNext;
-				override hasNext() {
-					//by the ime this method is finished readNext will contain the next readable element or this returns false
-					if (readNext!==null) return true;
-					while (true){
-						if (!parentIterator.hasNext) return false
-						readNext = parentIterator.next
-						val compareVal = extractFunction.apply(readNext)
-						if (!read.contains(compareVal)) {
-							read.add(compareVal);
-							return true;
-						}
-					}
-				}
-				
-				override next() {
-					if (hasNext) {
-						val result = readNext
-						readNext = null
-						return result
-					}
-					else {
-						throw new NoSuchElementException("read past end of iterator")
-					}
-				}
-				
-			}
-		}
-	}
-	
-	def static String fullname(RosettaType clazz) '''«clazz.model.name».«clazz.name»'''
-	def static String packageName(RosettaType clazz)  {clazz.model.name}
+    
+    static def <T> Iterable<T> distinct(Iterable<T> parentIterable) {
+        return new DistinctByIterator(parentIterable, [it])
+    }
+    static def <T,U> Iterable<T> distinctBy(Iterable<T> parentIterable, Function<T,U> extractFunction) {
+        return new DistinctByIterator(parentIterable, extractFunction)
+    }
+    
+    def static <T> boolean exists(Iterable<? super T> iter, Class<T> clazz) {
+        !iter.filter(clazz).empty
+    }
+    
+    private static class DistinctByIterator<T, U> implements Iterable<T>{
+        val Iterable<T> iterable;
+        val Function<T,U> extractFunction;
+        
+        new(Iterable<T> iterable, Function<T,U> extractFunction) {
+            this.iterable = iterable
+            this.extractFunction = extractFunction
+        }
+        
+        override iterator() {
+            val parentIterator = iterable.iterator
+            return new Iterator<T>() {
+                val read = newHashSet
+                var T readNext;
+                override hasNext() {
+                    //by the ime this method is finished readNext will contain the next readable element or this returns false
+                    if (readNext!==null) return true;
+                    while (true){
+                        if (!parentIterator.hasNext) return false
+                        readNext = parentIterator.next
+                        val compareVal = extractFunction.apply(readNext)
+                        if (!read.contains(compareVal)) {
+                            read.add(compareVal);
+                            return true;
+                        }
+                    }
+                }
+                
+                override next() {
+                    if (hasNext) {
+                        val result = readNext
+                        readNext = null
+                        return result
+                    }
+                    else {
+                        throw new NoSuchElementException("read past end of iterator")
+                    }
+                }
+                
+            }
+        }
+    }
+    
+    def static String fullname(RosettaType clazz) '''«clazz.model.name».«clazz.name»'''
+    def static String packageName(RosettaType clazz)  {clazz.model.name}
 }

--- a/python/test/run_serialization_test.sh
+++ b/python/test/run_serialization_test.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+function processError() {
+  echo ""
+  echo ""
+  echo "***************************************************************************"
+  echo "*                                                                         *"
+  echo "*                         INITIALISATION FAILED!                          *"
+  echo "*                  -- must be run from root directory --                  *"
+  echo "*                                                                         *"
+  echo "***************************************************************************"
+  echo ""
+  exit 1
+}
+
 type -P python > /dev/null && PYEXE=python || PYEXE=python3
 if ! $PYEXE -c 'import sys; assert sys.version_info >= (3,10)' > /dev/null 2>&1; then
         echo "Found $($PYEXE -V)"
@@ -6,20 +19,18 @@ if ! $PYEXE -c 'import sys; assert sys.version_info >= (3,10)' > /dev/null 2>&1;
         exit 1
 fi
 
+ACDIR=$($PYEXE -c "import sys;print('Scripts' if sys.platform.startswith('win') else 'bin')")
+
+$PYEXE -m venv --clear .pydevenv || processError
+source .pydevenv/$ACDIR/activate || processError
+
 MYPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+echo $MYPATH
 ROSETTARUNTIMEDIR="../src/main/resources/runtime"
 PYTHONCDMDIR="../target/python"
-cd $MYPATH
-
-ACDIR=$(python -c "import sys;print('Scripts' if sys.platform.startswith('win') else 'bin')")
-
-# rm -rf .testenv
-#$PYEXE -m venv --clear .pydevenv
-#source .pydevenv/$ACDIR/activate
-
 $PYEXE -m pip install pydantic
 $PYEXE -m pip install pytest
 $PYEXE -m pip install $MYPATH/$ROSETTARUNTIMEDIR/rosetta_runtime-3.0.0-py3-none-any.whl 
 $PYEXE -m pip install $MYPATH/$PYTHONCDMDIR/python_cdm-0.0.0-py3-none-any.whl
-$PYEXE ./tests/serialization/check_for_valid_cdm.py
+$PYEXE $MYPATH/tests/serialization/test_trade_state_product.py
 # rm -rf .pydevenv

--- a/python/test/tests/serialization/cdm_comparison_test.py
+++ b/python/test/tests/serialization/cdm_comparison_test.py
@@ -1,29 +1,47 @@
-''' Jsonn test utilities'''
+''' Compare CDM / JSON deserialization and serialization'''
 import json
 from pathlib import Path
 import sys
 import os
+from pydantic import ValidationError
+
 dirPath = os.path.dirname(__file__)
 sys.path.append(os.path.join(dirPath))
 
 from dict_comp import dict_comp
 from cdm.version import __build_time__
 
-
 def cdm_comparison_test_from_file(path, class_name):
     '''loads the json from a file and runs the comparison'''
-    print('testing: ' + path + ' with className: ' + class_name.__name__ + ' using CDM built at: ' + __build_time__)
+    print('testing: ',
+          path,
+          ' with className: ',
+          class_name.__name__,
+          ' using CDM built at: ',
+          __build_time__)
     json_str = Path(path).read_text()
-    cdm_comparison_test_from_string(json_str, class_name)
+    json_dict = json.loads (json_str)
+    print('json_dict["trade"]["tradeDate"]: ' + json.dumps(json_dict["trade"]["tradeDate"]))
+    try:
+        print('raw parse from json_str')
+        cdm_object = class_name.parse_raw(json_str)
+        trade = cdm_object.trade
+        print('trade.tradeDate:', str(trade.tradeDate))
+        json_data_out = cdm_object.model_dump_json(indent=4, exclude_defaults=True)
+        generated_dict = json.loads(json_data_out)    
+        assert dict_comp(json_dict, generated_dict), "Failed corrected dict comparison"
+        print('passed: dicts matched')
+    except ValidationError as e:
+        print('failed to parse')
+        print(e)
 
+def test_trade_state (cdm_sample_in=None):
+    '''test trade state'''
+    dir_path = os.path.dirname(__file__)
+    if cdm_sample_in is None:
+        sys.path.append(os.path.join(dir_path))
+        cdm_sample_in = os.path.join(dir_path, 'EUR-Vanilla-account.json')
+    cdm_comparison_test_from_file (cdm_sample_in, TradeState)
 
-def cdm_comparison_test_from_string(json_str, class_name):
-    '''loads the json from a string and runs the comparison'''
-    cdm_object = class_name.parse_raw(json_str)
-    json_data_out = cdm_object.model_dump_json(exclude_defaults=True, indent=4)
-    orig_dict = json.loads(json_str)
-    generated_dict = json.loads(json_data_out)    
-    assert dict_comp(orig_dict, generated_dict), "Failed corrected dict comparison"
-    print('passed: dicts matched')
 
 # EOF


### PR DESCRIPTION
build / test sequence
```
mvn clean install
./build/build_python_rosetta.sh
./test/run_serialization_test.sh
```

should result in 

```
testing:  .../rosetta-code-generators/python/test/tests/serialization/EUR-Vanilla-account.json  with className:  TradeState  using CDM built at:  2024-02-21T13:07:59.010741
json_dict["trade"]["tradeDate"]: {"value": "2018-01-29", "meta": {"globalKey": "3f105d"}}
raw parse from json_str
trade.tradeDate: meta={'globalKey': '3f105d'} value=datetime.date(2018, 1, 29)
passed: dicts matched
```